### PR TITLE
113008: Update GitHub actions cache version 4

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - name: Cache Gems
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-${{matrix.ruby_version}}-event_source-gems-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/Gemfile' ) }}


### PR DESCRIPTION
[Redmine Ticket](https://redmine.priv.dchbx.org/issues/113008)